### PR TITLE
feat: Skip group if the anchor is not eligible

### DIFF
--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/CanvasTracker.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/CanvasTracker.java
@@ -94,9 +94,6 @@ final class CanvasTracker implements LifecycleListener {
             if (group == null) {
                 continue;
             }
-            if (group.elements().stream().noneMatch(this::isEligible)) {
-                continue;
-            }
             this.client.accept(group);
             for (final var building : group.elements()) {
                 this.queue.remove(building.packed());

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/CanvasTracker.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/CanvasTracker.java
@@ -86,6 +86,10 @@ final class CanvasTracker implements LifecycleListener {
             final int point = this.queue.removeFirst();
             final var x = GeometryUtils.x(point);
             final var y = GeometryUtils.y(point);
+            final var anchor = this.canvases.select(x, y);
+            if (anchor == null || !this.isEligible(anchor)) {
+                continue;
+            }
             final var group = this.canvases.groupAt(x, y, MAX_GROUP_RANGE, visited);
             if (group == null) {
                 continue;

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/DisplayTracker.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/DisplayTracker.java
@@ -194,6 +194,10 @@ final class DisplayTracker implements LifecycleListener {
             final int point = this.queue.removeFirst();
             final var x = GeometryUtils.x(point);
             final var y = GeometryUtils.y(point);
+            final var anchor = this.displays.select(x, y);
+            if (anchor == null || !this.isEligible(anchor)) {
+                continue;
+            }
             final var group = this.displays.groupAt(x, y, MAX_GROUP_RANGE, visited);
             if (group == null) {
                 continue;
@@ -226,6 +230,10 @@ final class DisplayTracker implements LifecycleListener {
                     new MindustryDisplay(display.data().resolution(), Collections.unmodifiableMap(processors)));
             this.queue.addLast(GeometryUtils.pack(display.x(), display.y()));
         }
+    }
+
+    private boolean isEligible(final VirtualBuilding<MindustryDisplay> building) {
+        return !building.data().processors().isEmpty();
     }
 
     private enum LinkUpdateKind {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validations added to ensure a valid anchor item exists and is eligible before grouping or accepting work, reducing unnecessary processing.
  * Display eligibility now requires associated processors; positions without processors are skipped to avoid errors and wasted effort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->