### PR TITLE
feat: Restrict the number of concurrent requests to one

### DIFF
--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/CanvasTracker.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/CanvasTracker.java
@@ -78,7 +78,7 @@ final class CanvasTracker implements LifecycleListener {
     }
 
     private void collect() {
-        if (!Vars.state.isGame()) {
+        if (!Vars.state.isGame() || this.client.shouldNotAccept()) {
             return;
         }
         final var visited = new IntSet();

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/DisplayTracker.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/DisplayTracker.java
@@ -191,7 +191,7 @@ final class DisplayTracker implements LifecycleListener {
     }
 
     private void collect() {
-        if (!Vars.state.isGame()) {
+        if (!Vars.state.isGame() || this.client.shouldNotAccept()) {
             return;
         }
         final var visited = new IntSet();

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/NoHornyClient.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/NoHornyClient.java
@@ -78,36 +78,37 @@ final class NoHornyClient implements LifecycleListener {
 
     public <T extends MindustryImage> void accept(final VirtualBuilding.Group<T> group) {
         this.executor.execute(() -> {
-            for (int attempt = 0; attempt < RETRY_DELAYS.size(); attempt++) {
-                try {
+            try {
+                for (int attempt = 0; attempt < RETRY_DELAYS.size(); attempt++) {
                     final var delay = RETRY_DELAYS.get(attempt);
                     if (delay.isPositive()) {
                         Thread.sleep(delay);
                     }
                     this.semaphore.acquire();
-                    this.classify(group);
-                    return;
-                } catch (final InterruptedException _) {
-                    Thread.currentThread().interrupt();
-                    return;
-                } catch (final ConnectException e) {
-                    log.error(
-                            "Failed to rate group at ({}, {}), attempt {}/{}: The NoHorny server is not reachable",
-                            group.x(),
-                            group.y(),
-                            attempt + 1,
-                            RETRY_DELAYS.size());
-                } catch (final Exception e) {
-                    log.error(
-                            "Failed to rate group at ({}, {}), attempt {}/{}",
-                            group.x(),
-                            group.y(),
-                            attempt + 1,
-                            RETRY_DELAYS.size(),
-                            e);
-                } finally {
-                    this.semaphore.release();
+                    try {
+                        this.classify(group);
+                        return;
+                    } catch (final ConnectException e) {
+                        log.error(
+                                "Failed to rate group at ({}, {}), attempt {}/{}: The NoHorny server is not reachable",
+                                group.x(),
+                                group.y(),
+                                attempt + 1,
+                                RETRY_DELAYS.size());
+                    } catch (final Exception e) {
+                        log.error(
+                                "Failed to rate group at ({}, {}), attempt {}/{}",
+                                group.x(),
+                                group.y(),
+                                attempt + 1,
+                                RETRY_DELAYS.size(),
+                                e);
+                    } finally {
+                        this.semaphore.release();
+                    }
                 }
+            } catch (final InterruptedException _) {
+                Thread.currentThread().interrupt();
             }
         });
     }

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/NoHornyClient.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/NoHornyClient.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
 
@@ -37,6 +38,7 @@ final class NoHornyClient implements LifecycleListener {
             List.of(Duration.ZERO, Duration.ofSeconds(10), Duration.ofMinutes(2));
 
     private final HttpClient http = HttpClient.newHttpClient();
+    private final Semaphore semaphore = new Semaphore(1);
     private final ExecutorService executor = Executors.newThreadPerTaskExecutor(
             Thread.ofVirtual().name("nohorny-client-worker-", 0).factory());
 
@@ -69,11 +71,20 @@ final class NoHornyClient implements LifecycleListener {
         }
     }
 
+    // This is not a perfect concurrency guard, but it's simple, and it's also ok if a few groups slip through
+    public boolean shouldNotAccept() {
+        return this.semaphore.availablePermits() == 0;
+    }
+
     public <T extends MindustryImage> void accept(final VirtualBuilding.Group<T> group) {
         this.executor.execute(() -> {
             for (int attempt = 0; attempt < RETRY_DELAYS.size(); attempt++) {
                 try {
-                    Thread.sleep(RETRY_DELAYS.get(attempt));
+                    final var delay = RETRY_DELAYS.get(attempt);
+                    if (delay.isPositive()) {
+                        Thread.sleep(delay);
+                    }
+                    this.semaphore.acquire();
                     this.classify(group);
                     return;
                 } catch (final InterruptedException _) {
@@ -94,6 +105,8 @@ final class NoHornyClient implements LifecycleListener {
                             attempt + 1,
                             RETRY_DELAYS.size(),
                             e);
+                } finally {
+                    this.semaphore.release();
                 }
             }
         });


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xpdustry/codesmith/nohorny/pr/69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented processing of queued items when the client is unavailable, avoiding unwanted actions during downtime.
  * Added single-permit concurrency control for classification/acceptance tasks to stop overlapping or excessive processing and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->