### PR TITLE
Add support for http proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@ You can configure nohorny using the Mindustry built-in `config` command, with `c
 
 #### Available settings
 
-| Key                            | Description                                                                              | Default                            |
-|--------------------------------|------------------------------------------------------------------------------------------|------------------------------------|
-| `nohorny-api-endpoint`         | Base URL used by the plugin. The client resolves `status` and `classify` relative to it. | `https://nohorny.xpdustry.com/api` |
-| `nohorny-api-auth-type`        | HTTP auth mode for the API. Valid values: `DISABLED`, `BASIC`, `BEARER`.                 | `DISABLED`                         |
-| `nohorny-api-auth-value`       | Auth payload. For `BASIC`, use `username:password`. For `BEARER`, use the raw token.     | empty                              |
-| `nohorny-automod-policy`       | The policy to apply when a group of buildings is classified.                             | `BAN_NSFW`                         |
-| `nohorny-discord-webhook`      | Discord webhook used to report unsafe buildings.                                         | empty                              |
-| `nohorny-discord-webhook-name` | Username used for messages sent through the Discord webhook.                             | `NoHorny`                          |
-| `nohorny-debug-tap`            | Enables admin double-tap debugging for tracked displays and canvases.                    | `false`                            |
-| `nohorny-proxy-address`        | HTTP proxy used for API and Discord requests, in `host:port` format.                     | empty                              |
-| `nohorny-proxy-countries`      | Comma-separated ISO country codes to select a proxy from the Proxifly free proxy list.   | empty                              |
+| Key                                     | Description                                                                              | Default                            |
+|-----------------------------------------|------------------------------------------------------------------------------------------|------------------------------------|
+| `nohorny-api-endpoint`                  | Base URL used by the plugin. The client resolves `status` and `classify` relative to it. | `https://nohorny.xpdustry.com/api` |
+| `nohorny-api-auth-type`                 | HTTP auth mode for the API. Valid values: `DISABLED`, `BASIC`, `BEARER`.                 | `DISABLED`                         |
+| `nohorny-api-auth-value`                | Auth payload. For `BASIC`, use `username:password`. For `BEARER`, use the raw token.     | empty                              |
+| `nohorny-automod-policy`                | The policy to apply when a group of buildings is classified.                             | `BAN_NSFW`                         |
+| `nohorny-discord-webhook`               | Discord webhook used to report unsafe buildings.                                         | empty                              |
+| `nohorny-discord-webhook-name`          | Username used for messages sent through the Discord webhook.                             | `NoHorny`                          |
+| `nohorny-discord-webhook-proxy-enabled` | Whether discord requests should be proxied. Useful if discord is banned in the country.  | `false`                            |
+| `nohorny-debug-tap`                     | Enables admin double-tap debugging for tracked displays and canvases.                    | `false`                            |
+| `nohorny-proxy-countries`               | Comma-separated ISO country codes to select a proxy from the Proxifly free proxy list.   | `US`                               |
 
 #### Auto-Mod Policies
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ You can configure nohorny using the Mindustry built-in `config` command, with `c
 | `nohorny-discord-webhook`      | Discord webhook used to report unsafe buildings.                                         | empty                              |
 | `nohorny-discord-webhook-name` | Username used for messages sent through the Discord webhook.                             | `NoHorny`                          |
 | `nohorny-debug-tap`            | Enables admin double-tap debugging for tracked displays and canvases.                    | `false`                            |
+| `nohorny-proxy-address`        | HTTP proxy used for API and Discord requests, in `host:port` format.                     | empty                              |
+| `nohorny-proxy-countries`      | Comma-separated ISO country codes to select a proxy from the Proxifly free proxy list.   | empty                              |
 
 #### Auto-Mod Policies
 

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/DiscordWebhook.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/DiscordWebhook.java
@@ -50,9 +50,13 @@ final class DiscordWebhook implements LifecycleListener {
             if (webhook == null) {
                 return;
             }
-            if (event.key().equals(NoHornySetting.API_ENDPOINT) || event.key().equals(NoHornySetting.PROXY_COUNTRIES)) {
+            if (event.key().equals(NoHornySetting.DISCORD_WEBHOOK)
+                    || event.key().equals(NoHornySetting.DISCORD_WEBHOOK_NAME)
+                    || event.key().equals(NoHornySetting.PROXY_COUNTRIES)) {
                 this.executor.execute(() -> {
-                    this.proxy.refresh(true);
+                    if (event.key().equals(NoHornySetting.PROXY_COUNTRIES)) {
+                        this.proxy.refresh(true);
+                    }
                     if (event.key().equals(NoHornySetting.DISCORD_WEBHOOK)) {
                         this.onWebhookConfigure(webhook, "NSFW alerts will now be sent here.");
                     } else if (event.key().equals(NoHornySetting.DISCORD_WEBHOOK_NAME)) {

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/DiscordWebhook.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/DiscordWebhook.java
@@ -36,20 +36,32 @@ final class DiscordWebhook implements LifecycleListener {
     private static final int COMPONENT_TYPE_CONTAINER = 17;
     private static final int MESSAGE_FLAG_IS_COMPONENTS_V2 = 1 << 15;
 
-    private final HttpClient http;
     private final Mods.ModMeta metadata = Vars.mods.getMod(NoHornyPlugin.class).meta;
     private final MonoRateLimiter rateLimiter = new MonoRateLimiter(Duration.ofSeconds(1));
     private final ExecutorService executor = Executors.newThreadPerTaskExecutor(
             Thread.ofVirtual().name("nohorny-discord-webhook-", 0).factory());
+    private final ProxiflyProxySelector proxy = new ProxiflyProxySelector(this.executor);
+    private final HttpClient http =
+            HttpClient.newBuilder().executor(this.executor).proxy(this.proxy).build();
 
-    DiscordWebhook(final HttpClient http) {
-        this.http = http;
+    DiscordWebhook() {
         MindustryUtils.onEvent(SettingChangeEvent.class, event -> {
-            if (event.key().equals(NoHornySetting.DISCORD_WEBHOOK)) {
-                this.onWebhookConfigure("NSFW alerts will now be sent here.");
-            } else if (event.key().equals(NoHornySetting.DISCORD_WEBHOOK_NAME)) {
-                this.onWebhookConfigure(
-                        "The webhook username has been set to " + NoHornySetting.DISCORD_WEBHOOK_NAME.get() + ".");
+            final var webhook = NoHornySetting.DISCORD_WEBHOOK.get();
+            if (webhook == null) {
+                return;
+            }
+            if (event.key().equals(NoHornySetting.API_ENDPOINT) || event.key().equals(NoHornySetting.PROXY_COUNTRIES)) {
+                this.executor.execute(() -> {
+                    this.proxy.refresh(true);
+                    if (event.key().equals(NoHornySetting.DISCORD_WEBHOOK)) {
+                        this.onWebhookConfigure(webhook, "NSFW alerts will now be sent here.");
+                    } else if (event.key().equals(NoHornySetting.DISCORD_WEBHOOK_NAME)) {
+                        this.onWebhookConfigure(
+                                webhook,
+                                "The webhook username has been set to " + NoHornySetting.DISCORD_WEBHOOK_NAME.get()
+                                        + ".");
+                    }
+                });
             }
         });
     }
@@ -62,6 +74,15 @@ final class DiscordWebhook implements LifecycleListener {
     @Override
     public void onExit() {
         this.executor.close();
+        this.http.close();
+    }
+
+    private void onWebhookConfigure(final URI webhook, final String message) {
+        try {
+            this.send(webhook, this.createConfigurationSuccessFormPayload(message));
+        } catch (final Exception e) {
+            log.error("Failed to test the Discord webhook", e);
+        }
     }
 
     private void onClassificationEvent(final ClassificationEvent event) {
@@ -81,20 +102,6 @@ final class DiscordWebhook implements LifecycleListener {
                         event.group().x(),
                         event.group().y(),
                         e);
-            }
-        });
-    }
-
-    private void onWebhookConfigure(final String message) {
-        final var webhook = NoHornySetting.DISCORD_WEBHOOK.get();
-        if (webhook == null) {
-            return;
-        }
-        this.executor.execute(() -> {
-            try {
-                this.send(webhook, this.createConfigurationSuccessFormPayload(message));
-            } catch (final Exception e) {
-                log.error("Failed to test the Discord webhook", e);
             }
         });
     }

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/DiscordWebhook.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/DiscordWebhook.java
@@ -46,27 +46,28 @@ final class DiscordWebhook implements LifecycleListener {
 
     DiscordWebhook() {
         MindustryUtils.onEvent(SettingChangeEvent.class, event -> {
-            final var webhook = NoHornySetting.DISCORD_WEBHOOK.get();
-            if (webhook == null) {
+            if (!(event.key().equals(NoHornySetting.DISCORD_WEBHOOK)
+                    || event.key().equals(NoHornySetting.DISCORD_WEBHOOK_NAME)
+                    || event.key().equals(NoHornySetting.DISCORD_WEBHOOK_PROXY_ENABLED)
+                    || event.key().equals(NoHornySetting.PROXY_COUNTRIES))) {
                 return;
             }
-            if (event.key().equals(NoHornySetting.DISCORD_WEBHOOK)
-                    || event.key().equals(NoHornySetting.DISCORD_WEBHOOK_NAME)
-                    || event.key().equals(NoHornySetting.PROXY_COUNTRIES)) {
-                this.executor.execute(() -> {
-                    if (event.key().equals(NoHornySetting.PROXY_COUNTRIES)) {
-                        this.proxy.refresh(true);
-                    }
-                    if (event.key().equals(NoHornySetting.DISCORD_WEBHOOK)) {
-                        this.onWebhookConfigure(webhook, "NSFW alerts will now be sent here.");
-                    } else if (event.key().equals(NoHornySetting.DISCORD_WEBHOOK_NAME)) {
-                        this.onWebhookConfigure(
-                                webhook,
-                                "The webhook username has been set to " + NoHornySetting.DISCORD_WEBHOOK_NAME.get()
-                                        + ".");
-                    }
-                });
-            }
+            this.executor.execute(() -> {
+                final var webhook = NoHornySetting.DISCORD_WEBHOOK.get();
+                if (webhook == null) {
+                    return;
+                }
+                if (Boolean.TRUE.equals(NoHornySetting.DISCORD_WEBHOOK_PROXY_ENABLED.get())) {
+                    this.proxy.refresh(true);
+                }
+                if (event.key().equals(NoHornySetting.DISCORD_WEBHOOK)) {
+                    this.onWebhookConfigure(webhook, "NSFW alerts will now be sent here.");
+                } else if (event.key().equals(NoHornySetting.DISCORD_WEBHOOK_NAME)) {
+                    this.onWebhookConfigure(
+                            webhook,
+                            "The webhook username has been set to " + NoHornySetting.DISCORD_WEBHOOK_NAME.get() + ".");
+                }
+            });
         });
     }
 

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/DiscordWebhook.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/DiscordWebhook.java
@@ -80,6 +80,7 @@ final class DiscordWebhook implements LifecycleListener {
     public void onExit() {
         this.executor.close();
         this.http.close();
+        this.proxy.close();
     }
 
     private void onWebhookConfigure(final URI webhook, final String message) {

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/HttpUtils.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/HttpUtils.java
@@ -44,7 +44,7 @@ final class HttpUtils {
                 + (base.getPath().endsWith("/") ? "" : "/")
                 + Stream.of(segments)
                         .map(segment -> URLEncoder.encode(segment, StandardCharsets.UTF_8))
-                        .collect(Collectors.joining());
+                        .collect(Collectors.joining("/"));
         try {
             return new URI(
                     base.getScheme(),

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/HttpUtils.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/HttpUtils.java
@@ -5,8 +5,14 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 final class HttpUtils {
 
@@ -31,6 +37,27 @@ final class HttpUtils {
             });
             return in;
         });
+    }
+
+    public static URI appendPathSegments(final URI base, final String... segments) {
+        final var path = base.getPath()
+                + (base.getPath().endsWith("/") ? "" : "/")
+                + Stream.of(segments)
+                        .map(segment -> URLEncoder.encode(segment, StandardCharsets.UTF_8))
+                        .collect(Collectors.joining());
+        try {
+            return new URI(
+                    base.getScheme(),
+                    base.getUserInfo(),
+                    base.getHost(),
+                    base.getPort(),
+                    path,
+                    base.getQuery(),
+                    base.getFragment());
+        } catch (final URISyntaxException e) {
+            throw new IllegalArgumentException(
+                    "Failed to append path segments " + String.join("/", segments) + " to " + base, e);
+        }
     }
 
     private HttpUtils() {}

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/MiniLogger.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/MiniLogger.java
@@ -12,10 +12,11 @@ sealed interface MiniLogger {
 
     static MiniLogger forClass(final Class<?> clazz) {
         final var fallback = MindustryMiniLogger.INSTANCE;
-        if (Vars.mods.getMod("slf4md") != null) {
+        if (!SLF4MDMiniLogger.isFailureReported && Vars.mods != null && Vars.mods.getMod("slf4md") != null) {
             try {
                 return new SLF4MDMiniLogger(clazz);
             } catch (final ReflectiveOperationException e) {
+                SLF4MDMiniLogger.isFailureReported = true;
                 fallback.error("Failed to create slf4md logger", e);
             }
         }
@@ -43,8 +44,8 @@ sealed interface MiniLogger {
     void log(final Level level, final String message, final @Nullable Object... args);
 
     final class SLF4MDMiniLogger implements MiniLogger {
+        private static volatile boolean isFailureReported = false;
         private final Object logger;
-        private boolean isFailureReported = false;
 
         private SLF4MDMiniLogger(final Class<?> clazz) throws ReflectiveOperationException {
             final var factory = Class.forName("org.slf4j.LoggerFactory");
@@ -60,9 +61,9 @@ sealed interface MiniLogger {
                 log.invoke(this.logger, message, args);
             } catch (final ReflectiveOperationException e) {
                 final var fallback = MindustryMiniLogger.INSTANCE;
-                if (!this.isFailureReported) {
+                if (!isFailureReported) {
                     fallback.error("Failed to log message using slf4md", e);
-                    this.isFailureReported = true;
+                    isFailureReported = true;
                 }
                 fallback.log(level, message, args);
             }

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/MiniLogger.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/MiniLogger.java
@@ -44,7 +44,7 @@ sealed interface MiniLogger {
     void log(final Level level, final String message, final @Nullable Object... args);
 
     final class SLF4MDMiniLogger implements MiniLogger {
-        private static volatile boolean isFailureReported = false;
+        private static boolean isFailureReported = false;
         private final Object logger;
 
         private SLF4MDMiniLogger(final Class<?> clazz) throws ReflectiveOperationException {

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/NoHornyClient.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/NoHornyClient.java
@@ -14,7 +14,6 @@ import com.xpdustry.nohorny.common.Rating;
 import com.xpdustry.nohorny.common.VirtualBuilding;
 import java.io.IOException;
 import java.net.ConnectException;
-import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -34,13 +33,13 @@ final class NoHornyClient implements LifecycleListener {
 
     private static final MiniLogger log = MiniLogger.forClass(NoHornyClient.class);
 
-    private final HttpClient http;
-    private final Semaphore classificationPermit = new Semaphore(1);
+    private final Semaphore classificationPermits = new Semaphore(1);
     private final ExecutorService executor = Executors.newThreadPerTaskExecutor(
             Thread.ofVirtual().name("nohorny-client-worker-", 0).factory());
+    private final HttpClient http =
+            HttpClient.newBuilder().executor(this.executor).build();
 
-    NoHornyClient(final HttpClient http) {
-        this.http = http;
+    NoHornyClient() {
         MindustryUtils.onEvent(SettingChangeEvent.class, event -> {
             if (event.key().equals(NoHornySetting.API_ENDPOINT)
                     || event.key().equals(NoHornySetting.API_AUTH_TYPE)
@@ -53,6 +52,12 @@ final class NoHornyClient implements LifecycleListener {
     @Override
     public void onInit() {
         this.checkEndpointStatus();
+    }
+
+    @Override
+    public void onExit() {
+        this.executor.close();
+        this.http.close();
     }
 
     private void checkEndpointStatus() {
@@ -82,7 +87,7 @@ final class NoHornyClient implements LifecycleListener {
     }
 
     public <T extends MindustryImage> boolean tryAccept(final VirtualBuilding.Group<T> group) {
-        if (!this.classificationPermit.tryAcquire()) {
+        if (!this.classificationPermits.tryAcquire()) {
             return false;
         }
         try {
@@ -97,12 +102,12 @@ final class NoHornyClient implements LifecycleListener {
                 } catch (final Exception e) {
                     log.error("Failed to rate group at ({}, {})", group.x(), group.y(), e);
                 } finally {
-                    this.classificationPermit.release();
+                    this.classificationPermits.release();
                 }
             });
             return true;
         } catch (final RejectedExecutionException _) {
-            this.classificationPermit.release();
+            this.classificationPermits.release();
             return false;
         }
     }
@@ -158,10 +163,8 @@ final class NoHornyClient implements LifecycleListener {
         if (endpoint == null) {
             throw new IllegalStateException("NoHorny API endpoint is disabled");
         }
-        final var base = endpoint.toString();
-        final var normalized = base.endsWith("/") ? base : base + "/";
-        final var uri = URI.create(normalized).resolve(path);
-        final var request = HttpRequest.newBuilder(uri).timeout(timeout);
+        final var request = HttpRequest.newBuilder(HttpUtils.appendPathSegments(endpoint, path))
+                .timeout(timeout);
         final var authorization = this.authorization();
         if (authorization != null) {
             request.header("Authorization", authorization);

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/NoHornyPlugin.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/NoHornyPlugin.java
@@ -54,7 +54,7 @@ public final class NoHornyPlugin extends Plugin {
             try {
                 this.listeners.get(i).onInit();
             } catch (final Exception e1) {
-                for (; i > 0; --i) {
+                for (; i >= 0; --i) {
                     try {
                         this.listeners.get(i).onExit();
                     } catch (final Exception e2) {

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/NoHornyPlugin.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/NoHornyPlugin.java
@@ -3,7 +3,6 @@ package com.xpdustry.nohorny.client;
 
 import arc.ApplicationListener;
 import arc.Core;
-import java.net.http.HttpClient;
 import java.util.ArrayList;
 import java.util.List;
 import mindustry.Vars;
@@ -20,9 +19,7 @@ public final class NoHornyPlugin extends Plugin {
     public void init() {
         final var directory = Vars.mods.getConfigFolder(this).file().toPath();
 
-        final var http = HttpClient.newHttpClient();
-
-        final var client = new NoHornyClient(http);
+        final var client = new NoHornyClient();
         this.addListener(client);
 
         final var displays = new DisplayTracker(client);
@@ -34,19 +31,13 @@ public final class NoHornyPlugin extends Plugin {
         final var debug = new DebugHelper(directory.resolve("debug"), canvases, displays);
         this.addListener(debug);
 
-        this.addListener(new DiscordWebhook(http));
+        this.addListener(new DiscordWebhook());
 
         this.addListener(new AutoModerator());
 
-        this.addListener(new LifecycleListener() {
-            @Override
-            public void onExit() {
-                http.close();
-            }
-        });
-
         this.init0();
         Core.app.addListener(new ApplicationListener() {
+
             @Override
             public void dispose() {
                 NoHornyPlugin.this.exit0();

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/NoHornySetting.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/NoHornySetting.java
@@ -65,14 +65,30 @@ public interface NoHornySetting<T> {
             eg: "true", "false".
             """, false, Boolean.class, SettingCodec.OfBoolean);
 
+    NoHornySetting<Boolean> DISCORD_WEBHOOK_PROXY_ENABLED =
+            new AdminConfigNoHornySetting<>("proxy-countries", """
+            Whether discord requests should be proxied.
+            Useful if discord is banned in the server's country.
+            eg: "true", "false".
+            """, false, Boolean.class, SettingCodec.OfBoolean);
+
+    NoHornySetting<String> PROXY_COUNTRIES =
+            new AdminConfigNoHornySetting<>("proxy-countries", """
+            Comma separated list of ISO 3166-1 alpha-2 country codes used to select a proxy.
+            Setting this to null defaults to the "US".
+            eg: "FR,DE,US".
+            """, "US", String.class, SettingCodec.OfCountryCodeList);
+
     List<NoHornySetting<?>> ALL = List.of(
             API_ENDPOINT,
             API_AUTH_TYPE,
             API_AUTH_VALUE,
             DISCORD_WEBHOOK,
             DISCORD_WEBHOOK_NAME,
+            DISCORD_WEBHOOK_PROXY_ENABLED,
             AUTOMOD_POLICY,
-            DEBUG_TAP);
+            DEBUG_TAP,
+            PROXY_COUNTRIES);
 
     String name();
 

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/NoHornySetting.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/NoHornySetting.java
@@ -65,8 +65,8 @@ public interface NoHornySetting<T> {
             eg: "true", "false".
             """, false, Boolean.class, SettingCodec.OfBoolean);
 
-    NoHornySetting<Boolean> DISCORD_WEBHOOK_PROXY_ENABLED =
-            new AdminConfigNoHornySetting<>("proxy-countries", """
+    NoHornySetting<Boolean> DISCORD_WEBHOOK_PROXY_ENABLED = new AdminConfigNoHornySetting<>(
+            "discord-webhook-proxy-enabled", """
             Whether discord requests should be proxied.
             Useful if discord is banned in the server's country.
             eg: "true", "false".

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/ProxiflyProxySelector.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/ProxiflyProxySelector.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 import javax.net.ssl.HttpsURLConnection;
 import org.jspecify.annotations.Nullable;
 
-final class ProxiflyProxySelector extends ProxySelector {
+final class ProxiflyProxySelector extends ProxySelector implements AutoCloseable {
 
     private static final MiniLogger log = MiniLogger.forClass(ProxiflyProxySelector.class);
 
@@ -270,5 +270,10 @@ final class ProxiflyProxySelector extends ProxySelector {
             return null;
         }
         return new InetSocketAddress(InetAddress.ofLiteral(ip), port);
+    }
+
+    @Override
+    public void close() {
+        this.http.close();
     }
 }

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/ProxiflyProxySelector.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/ProxiflyProxySelector.java
@@ -5,10 +5,12 @@ import arc.util.serialization.Jval;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.SocketAddress;
 import java.net.URI;
+import java.net.URL;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -27,24 +29,41 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.HttpsURLConnection;
 import org.jspecify.annotations.Nullable;
 
 final class ProxiflyProxySelector extends ProxySelector {
 
     private static final MiniLogger log = MiniLogger.forClass(ProxiflyProxySelector.class);
+
     private static final URI PROXY_LIST_ENDPOINT =
             URI.create("https://cdn.jsdelivr.net/gh/proxifly/free-proxy-list@main/proxies/countries/");
-    private static final URI DISCORD_STATUS_ENDPOINT = URI.create("https://discord.com/api/v10/gateway");
+    private static final URL DISCORD_STATUS_ENDPOINT;
+
+    static {
+        try {
+            DISCORD_STATUS_ENDPOINT =
+                    URI.create("https://discord.com/api/v10/gateway").toURL();
+        } catch (final MalformedURLException e) {
+            throw new RuntimeException("How?", e);
+        }
+    }
+
     private static final Duration TIMEOUT = Duration.ofSeconds(2);
-    private static final int TEST_BATCH_SIZE = 16;
+    private static final int TEST_BATCH_SIZE = 128;
 
     private final Executor executor;
+    private final HttpClient http;
     private final Object lock = new Object();
     private @Nullable Proxy proxy = null;
     private Instant refreshAt = Instant.MIN;
 
     ProxiflyProxySelector(final Executor executor) {
         this.executor = executor;
+        this.http = HttpClient.newBuilder()
+                .connectTimeout(TIMEOUT)
+                .executor(this.executor)
+                .build();
     }
 
     @Override
@@ -87,17 +106,21 @@ final class ProxiflyProxySelector extends ProxySelector {
                 return this.proxy;
             }
 
+            final var start = System.currentTimeMillis();
             final var countries = Objects.requireNonNullElse(NoHornySetting.PROXY_COUNTRIES.get(), "US");
             final var proxies = this.fetchProxies(Arrays.stream(countries.split(",", -1))
                     .map(c -> c.toUpperCase(Locale.ROOT))
                     .toList());
 
             Proxy result = null;
-            for (int start = 0; start < proxies.size(); start += TEST_BATCH_SIZE) {
-                final var batch = proxies.subList(start, Math.min(start + TEST_BATCH_SIZE, proxies.size()));
+            for (int i = 0; i < proxies.size(); i += TEST_BATCH_SIZE) {
+                final var batch = proxies.subList(i, Math.min(i + TEST_BATCH_SIZE, proxies.size()));
                 final var proxy = this.testProxyBatch(batch);
                 if (proxy != null) {
-                    log.debug("Selected the Proxifly proxy {}", proxy.address());
+                    log.debug(
+                            "Selected the Proxifly proxy {} in {}ms",
+                            proxy.address(),
+                            System.currentTimeMillis() - start);
                     result = proxy;
                     break;
                 }
@@ -157,22 +180,36 @@ final class ProxiflyProxySelector extends ProxySelector {
 
     @SuppressWarnings("EmptyCatch")
     private Optional<Proxy> testProxy(final InetSocketAddress address) {
-        try (final var http = HttpClient.newBuilder()
-                .proxy(ProxySelector.of(address))
-                .connectTimeout(TIMEOUT)
-                .build()) {
-            final var response = http.send(
-                    HttpRequest.newBuilder(DISCORD_STATUS_ENDPOINT)
-                            .timeout(TIMEOUT)
-                            .GET()
-                            .build(),
-                    HttpResponse.BodyHandlers.discarding());
-            if (response.statusCode() == 200) {
-                return Optional.of(new Proxy(Proxy.Type.HTTP, address));
+        final var proxy = new Proxy(Proxy.Type.HTTP, address);
+        final HttpsURLConnection connection;
+        try {
+            connection = (HttpsURLConnection) DISCORD_STATUS_ENDPOINT.openConnection(proxy);
+        } catch (final IOException e) {
+            return Optional.empty();
+        }
+        try {
+            connection.setConnectTimeout((int) TIMEOUT.toMillis());
+            connection.setReadTimeout((int) TIMEOUT.toMillis());
+            connection.setRequestMethod("GET");
+            connection.setUseCaches(false);
+            connection.setRequestProperty("Connection", "close");
+            if (connection.getResponseCode() == HttpsURLConnection.HTTP_OK) {
+                return Optional.of(proxy);
             }
-        } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
         } catch (final IOException _) {
+        } finally {
+            try {
+                connection.getInputStream().close();
+            } catch (final IOException _) {
+            }
+            try {
+                final var error = connection.getErrorStream();
+                if (error != null) {
+                    error.close();
+                }
+            } catch (final IOException _) {
+            }
+            connection.disconnect();
         }
         return Optional.empty();
     }
@@ -181,44 +218,41 @@ final class ProxiflyProxySelector extends ProxySelector {
     @SuppressWarnings("EmptyCatch")
     private List<InetSocketAddress> fetchProxies(final List<String> countries) {
         final var addresses = new HashSet<InetSocketAddress>();
-        try (final var http = HttpClient.newBuilder().connectTimeout(TIMEOUT).build()) {
-            for (final var country : countries) {
-                final var request = HttpRequest.newBuilder(
-                                HttpUtils.appendPathSegments(PROXY_LIST_ENDPOINT, country, "data.json"))
-                        .timeout(TIMEOUT)
-                        .GET()
-                        .build();
-                final HttpResponse<String> response;
-                try {
-                    response = http.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
-                } catch (final InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    continue;
-                } catch (final IOException e) {
-                    log.error("Failed to fetch the Proxifly proxy list of {}", country, e);
-                    continue;
-                }
-                if (response.statusCode() != 200) {
-                    log.error(
-                            "The Proxifly proxy list of {} returned the http code {}", country, response.statusCode());
-                    continue;
-                }
-                try {
-                    for (final var element : Jval.read(response.body()).asArray()) {
-                        try {
-                            final var address = this.parseProxy(element);
-                            if (address != null) {
-                                addresses.add(address);
-                            }
-                        } catch (final Exception _) {
-                        }
-                    }
-                } catch (final Exception e) {
-                    log.error("Failed to parse the Proxifly proxy list of {}", country, e);
-                }
+        for (final var country : countries) {
+            final var request = HttpRequest.newBuilder(
+                            HttpUtils.appendPathSegments(PROXY_LIST_ENDPOINT, country, "data.json"))
+                    .timeout(TIMEOUT)
+                    .GET()
+                    .build();
+            final HttpResponse<String> response;
+            try {
+                response = this.http.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                continue;
+            } catch (final IOException e) {
+                log.error("Failed to fetch the Proxifly proxy list of {}", country, e);
+                continue;
             }
-            return List.copyOf(addresses);
+            if (response.statusCode() != 200) {
+                log.error("The Proxifly proxy list of {} returned the http code {}", country, response.statusCode());
+                continue;
+            }
+            try {
+                for (final var element : Jval.read(response.body()).asArray()) {
+                    try {
+                        final var address = this.parseProxy(element);
+                        if (address != null) {
+                            addresses.add(address);
+                        }
+                    } catch (final Exception _) {
+                    }
+                }
+            } catch (final Exception e) {
+                log.error("Failed to parse the Proxifly proxy list of {}", country, e);
+            }
         }
+        return List.copyOf(addresses);
     }
 
     private @Nullable InetSocketAddress parseProxy(final Jval element) {

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/ProxiflyProxySelector.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/ProxiflyProxySelector.java
@@ -127,12 +127,13 @@ final class ProxiflyProxySelector extends ProxySelector {
             }
             if (result != null) {
                 this.proxy = result;
+                this.refreshAt = Instant.now().plus(10, ChronoUnit.MINUTES);
             } else {
                 log.error("No working Proxifly proxy was found for the countries {}", countries);
                 this.proxy = null;
+                this.refreshAt = Instant.MIN;
             }
 
-            this.refreshAt = Instant.now().plus(10, ChronoUnit.MINUTES);
             return this.proxy;
         }
     }

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/ProxiflyProxySelector.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/ProxiflyProxySelector.java
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: MIT
+package com.xpdustry.nohorny.client;
+
+import arc.util.serialization.Jval;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.jspecify.annotations.Nullable;
+
+final class ProxiflyProxySelector extends ProxySelector {
+
+    private static final MiniLogger log = MiniLogger.forClass(ProxiflyProxySelector.class);
+    private static final URI PROXY_LIST_ENDPOINT =
+            URI.create("https://cdn.jsdelivr.net/gh/proxifly/free-proxy-list@main/proxies/countries/");
+    private static final Duration TIMEOUT = Duration.ofSeconds(2);
+    private static final int TEST_BATCH_SIZE = 16;
+
+    private final Executor executor;
+    private final Object lock = new Object();
+    private @Nullable Proxy proxy = null;
+    private Instant refreshAt = Instant.MIN;
+
+    ProxiflyProxySelector(final Executor executor) {
+        this.executor = executor;
+    }
+
+    @Override
+    public List<Proxy> select(final URI uri) {
+        Objects.requireNonNull(uri.getScheme(), "uri.scheme");
+        Objects.requireNonNull(uri.getHost(), "uri.host");
+
+        if (!uri.getScheme().equalsIgnoreCase("http") && !uri.getScheme().equalsIgnoreCase("https")) {
+            return ProxySelector.getDefault().select(uri);
+        }
+
+        final var proxy = this.refresh(false);
+        return proxy == null ? ProxySelector.getDefault().select(uri) : List.of(proxy);
+    }
+
+    @Override
+    public void connectFailed(final URI uri, final SocketAddress sa, final IOException ioe) {
+        Objects.requireNonNull(uri.getScheme(), "uri.scheme");
+        Objects.requireNonNull(uri.getHost(), "uri.host");
+
+        if (!uri.getScheme().equalsIgnoreCase("http") && !uri.getScheme().equalsIgnoreCase("https")) {
+            return;
+        }
+
+        synchronized (this.lock) {
+            if (this.proxy != null && this.proxy.address().equals(sa)) {
+                this.proxy = null;
+                this.refreshAt = Instant.MIN;
+            }
+        }
+    }
+
+    @Nullable Proxy refresh(final boolean force) {
+        synchronized (this.lock) {
+            if (!force && this.refreshAt.isAfter(Instant.now())) {
+                return this.proxy;
+            }
+            final var endpoint = NoHornySetting.API_ENDPOINT.get();
+            if (endpoint == null) {
+                this.refreshAt = Instant.MIN;
+                return null;
+            }
+
+            final var countries = Objects.requireNonNullElse(NoHornySetting.PROXY_COUNTRIES.get(), "US");
+            final var proxies = this.fetchProxies(Arrays.stream(countries.split(",", -1))
+                    .map(c -> c.toUpperCase(Locale.ROOT))
+                    .toList());
+            final var status = HttpUtils.appendPathSegments(endpoint, "status");
+
+            Proxy result = null;
+            for (int start = 0; start < proxies.size(); start += TEST_BATCH_SIZE) {
+                final var batch = proxies.subList(start, Math.min(start + TEST_BATCH_SIZE, proxies.size()));
+                final var proxy = this.testProxyBatch(batch, status);
+                if (proxy != null) {
+                    log.debug("Selected the Proxifly proxy {}", proxy.address());
+                    result = proxy;
+                    break;
+                }
+            }
+            if (result != null) {
+                this.proxy = result;
+            } else {
+                log.error("No working Proxifly proxy was found for the countries {}", countries);
+            }
+
+            this.refreshAt = Instant.now().plus(10, ChronoUnit.MINUTES);
+            return this.proxy;
+        }
+    }
+
+    private @Nullable Proxy testProxyBatch(final List<InetSocketAddress> batch, final URI status) {
+        final var completion = new ExecutorCompletionService<Optional<Proxy>>(this.executor);
+        final var tasks = new ArrayList<Future<Optional<Proxy>>>(batch.size());
+        try {
+            for (final var address : batch) {
+                tasks.add(completion.submit(() -> this.testProxy(address, status)));
+            }
+            final var deadline = System.nanoTime() + TIMEOUT.toNanos();
+            for (int i = 0; i < tasks.size(); i++) {
+                final var remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    break;
+                }
+                final Future<Optional<Proxy>> completed;
+                try {
+                    completed = completion.poll(remaining, TimeUnit.NANOSECONDS);
+                } catch (final InterruptedException _) {
+                    Thread.currentThread().interrupt();
+                    return null;
+                }
+                if (completed == null) {
+                    break;
+                }
+                if (completed.state() == Future.State.SUCCESS) {
+                    final var proxy = completed.resultNow();
+                    if (proxy.isPresent()) {
+                        for (final var task : tasks) {
+                            task.cancel(true);
+                        }
+                        return proxy.get();
+                    }
+                }
+            }
+        } finally {
+            for (final var task : tasks) {
+                task.cancel(true);
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("EmptyCatch")
+    private Optional<Proxy> testProxy(final InetSocketAddress address, final URI status) {
+        try (final var http = HttpClient.newBuilder()
+                .proxy(ProxySelector.of(address))
+                .connectTimeout(TIMEOUT)
+                .build()) {
+            final var response = http.send(
+                    HttpRequest.newBuilder(status).timeout(TIMEOUT).GET().build(),
+                    HttpResponse.BodyHandlers.discarding());
+            if (response.statusCode() == 200) {
+                return Optional.of(new Proxy(Proxy.Type.HTTP, address));
+            }
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (final IOException _) {
+        }
+        return Optional.empty();
+    }
+
+    // TODO Parallelize too?
+    @SuppressWarnings("EmptyCatch")
+    private List<InetSocketAddress> fetchProxies(final List<String> countries) {
+        final var addresses = new HashSet<InetSocketAddress>();
+        try (final var http = HttpClient.newBuilder().connectTimeout(TIMEOUT).build()) {
+            for (final var country : countries) {
+                final var request = HttpRequest.newBuilder(
+                                HttpUtils.appendPathSegments(PROXY_LIST_ENDPOINT, country, "data.json"))
+                        .timeout(TIMEOUT)
+                        .GET()
+                        .build();
+                final HttpResponse<String> response;
+                try {
+                    response = http.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    continue;
+                } catch (final IOException e) {
+                    log.error("Failed to fetch the Proxifly proxy list of {}", country, e);
+                    continue;
+                }
+                if (response.statusCode() != 200) {
+                    log.error(
+                            "The Proxifly proxy list of {} returned the http code {}", country, response.statusCode());
+                    continue;
+                }
+                for (final var element : Jval.read(response.body()).asArray()) {
+                    try {
+                        final var address = this.parseProxy(element);
+                        if (address != null) {
+                            addresses.add(address);
+                        }
+                    } catch (final Exception _) {
+                    }
+                }
+            }
+            return List.copyOf(addresses);
+        }
+    }
+
+    private @Nullable InetSocketAddress parseProxy(final Jval element) {
+        final var protocol = element.getString("protocol", "");
+        if (!protocol.equals("http") && !protocol.equals("https")) {
+            return null;
+        }
+        final var ip = element.getString("ip", "");
+        if (ip.isEmpty()) {
+            return null;
+        }
+        final var port = element.getInt("port", -1);
+        if (port <= 0 || port > 65535) {
+            return null;
+        }
+        return new InetSocketAddress(InetAddress.ofLiteral(ip), port);
+    }
+}

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/ProxiflyProxySelector.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/ProxiflyProxySelector.java
@@ -34,6 +34,7 @@ final class ProxiflyProxySelector extends ProxySelector {
     private static final MiniLogger log = MiniLogger.forClass(ProxiflyProxySelector.class);
     private static final URI PROXY_LIST_ENDPOINT =
             URI.create("https://cdn.jsdelivr.net/gh/proxifly/free-proxy-list@main/proxies/countries/");
+    private static final URI DISCORD_STATUS_ENDPOINT = URI.create("https://discord.com/api/v10/gateway");
     private static final Duration TIMEOUT = Duration.ofSeconds(2);
     private static final int TEST_BATCH_SIZE = 16;
 
@@ -52,6 +53,10 @@ final class ProxiflyProxySelector extends ProxySelector {
         Objects.requireNonNull(uri.getHost(), "uri.host");
 
         if (!uri.getScheme().equalsIgnoreCase("http") && !uri.getScheme().equalsIgnoreCase("https")) {
+            return ProxySelector.getDefault().select(uri);
+        }
+
+        if (!Boolean.TRUE.equals(NoHornySetting.DISCORD_WEBHOOK_PROXY_ENABLED.get())) {
             return ProxySelector.getDefault().select(uri);
         }
 
@@ -81,22 +86,16 @@ final class ProxiflyProxySelector extends ProxySelector {
             if (!force && this.refreshAt.isAfter(Instant.now())) {
                 return this.proxy;
             }
-            final var endpoint = NoHornySetting.API_ENDPOINT.get();
-            if (endpoint == null) {
-                this.refreshAt = Instant.MIN;
-                return null;
-            }
 
             final var countries = Objects.requireNonNullElse(NoHornySetting.PROXY_COUNTRIES.get(), "US");
             final var proxies = this.fetchProxies(Arrays.stream(countries.split(",", -1))
                     .map(c -> c.toUpperCase(Locale.ROOT))
                     .toList());
-            final var status = HttpUtils.appendPathSegments(endpoint, "status");
 
             Proxy result = null;
             for (int start = 0; start < proxies.size(); start += TEST_BATCH_SIZE) {
                 final var batch = proxies.subList(start, Math.min(start + TEST_BATCH_SIZE, proxies.size()));
-                final var proxy = this.testProxyBatch(batch, status);
+                final var proxy = this.testProxyBatch(batch);
                 if (proxy != null) {
                     log.debug("Selected the Proxifly proxy {}", proxy.address());
                     result = proxy;
@@ -107,6 +106,7 @@ final class ProxiflyProxySelector extends ProxySelector {
                 this.proxy = result;
             } else {
                 log.error("No working Proxifly proxy was found for the countries {}", countries);
+                this.proxy = null;
             }
 
             this.refreshAt = Instant.now().plus(10, ChronoUnit.MINUTES);
@@ -114,12 +114,12 @@ final class ProxiflyProxySelector extends ProxySelector {
         }
     }
 
-    private @Nullable Proxy testProxyBatch(final List<InetSocketAddress> batch, final URI status) {
+    private @Nullable Proxy testProxyBatch(final List<InetSocketAddress> batch) {
         final var completion = new ExecutorCompletionService<Optional<Proxy>>(this.executor);
         final var tasks = new ArrayList<Future<Optional<Proxy>>>(batch.size());
         try {
             for (final var address : batch) {
-                tasks.add(completion.submit(() -> this.testProxy(address, status)));
+                tasks.add(completion.submit(() -> this.testProxy(address)));
             }
             final var deadline = System.nanoTime() + TIMEOUT.toNanos();
             for (int i = 0; i < tasks.size(); i++) {
@@ -156,13 +156,16 @@ final class ProxiflyProxySelector extends ProxySelector {
     }
 
     @SuppressWarnings("EmptyCatch")
-    private Optional<Proxy> testProxy(final InetSocketAddress address, final URI status) {
+    private Optional<Proxy> testProxy(final InetSocketAddress address) {
         try (final var http = HttpClient.newBuilder()
                 .proxy(ProxySelector.of(address))
                 .connectTimeout(TIMEOUT)
                 .build()) {
             final var response = http.send(
-                    HttpRequest.newBuilder(status).timeout(TIMEOUT).GET().build(),
+                    HttpRequest.newBuilder(DISCORD_STATUS_ENDPOINT)
+                            .timeout(TIMEOUT)
+                            .GET()
+                            .build(),
                     HttpResponse.BodyHandlers.discarding());
             if (response.statusCode() == 200) {
                 return Optional.of(new Proxy(Proxy.Type.HTTP, address));
@@ -200,14 +203,18 @@ final class ProxiflyProxySelector extends ProxySelector {
                             "The Proxifly proxy list of {} returned the http code {}", country, response.statusCode());
                     continue;
                 }
-                for (final var element : Jval.read(response.body()).asArray()) {
-                    try {
-                        final var address = this.parseProxy(element);
-                        if (address != null) {
-                            addresses.add(address);
+                try {
+                    for (final var element : Jval.read(response.body()).asArray()) {
+                        try {
+                            final var address = this.parseProxy(element);
+                            if (address != null) {
+                                addresses.add(address);
+                            }
+                        } catch (final Exception _) {
                         }
-                    } catch (final Exception _) {
                     }
+                } catch (final Exception e) {
+                    log.error("Failed to parse the Proxifly proxy list of {}", country, e);
                 }
             }
             return List.copyOf(addresses);

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/SettingCodec.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/SettingCodec.java
@@ -2,6 +2,7 @@
 package com.xpdustry.nohorny.client;
 
 import java.net.URI;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 
 interface SettingCodec<T> {
@@ -24,6 +25,33 @@ interface SettingCodec<T> {
         @Override
         public String toString() {
             return "SettingCodec.OfString";
+        }
+    };
+
+    SettingCodec<String> OfCountryCodeList = new SettingCodec<>() {
+        @Override
+        public String encode(final String value) {
+            return value;
+        }
+
+        @Override
+        public String decode(final String value) {
+            final var countries = new LinkedHashSet<String>();
+            for (final var element : value.split(",", -1)) {
+                final var country = element.trim().toUpperCase(Locale.ROOT);
+                if (country.length() != 2 || country.chars().anyMatch(c -> c < 'A' || c > 'Z')) {
+                    throw new IllegalArgumentException("'" + element + "' is not a two letter country code");
+                }
+                if (!countries.add(country)) {
+                    throw new IllegalArgumentException("'" + country + "' appears more than once");
+                }
+            }
+            return String.join(",", countries);
+        }
+
+        @Override
+        public String toString() {
+            return "SettingCodec.OfCountryCodeList";
         }
     };
 

--- a/nohorny-client/src/test/java/com/xpdustry/nohorny/client/ProxiflyProxySelectorTest.java
+++ b/nohorny-client/src/test/java/com/xpdustry/nohorny/client/ProxiflyProxySelectorTest.java
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+package com.xpdustry.nohorny.client;
+
+import arc.Core;
+import arc.mock.MockSettings;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+final class ProxiflyProxySelectorTest {
+
+    @BeforeEach
+    void before() {
+        Core.settings = new MockSettings();
+    }
+
+    @AfterEach
+    void after() {
+        Core.settings = null;
+    }
+
+    @EnabledIfEnvironmentVariable(named = "CI", matches = "true|1")
+    @Test
+    void select_working_proxy_from_live_proxifly_list() {
+        try (final var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            final var selector = new ProxiflyProxySelector(executor);
+            final var proxy = selector.refresh(true);
+            assertNotNull(proxy, "Expected a Proxifly HTTP proxy capable of reaching Discord's gateway endpoint");
+            assertEquals(Proxy.Type.HTTP, proxy.type());
+            assertInstanceOf(InetSocketAddress.class, proxy.address());
+        }
+    }
+}

--- a/nohorny-server/src/main/java/com/xpdustry/nohorny/server/classifier/HuggingFaceViTModelSource.java
+++ b/nohorny-server/src/main/java/com/xpdustry/nohorny/server/classifier/HuggingFaceViTModelSource.java
@@ -28,6 +28,7 @@ public final class HuggingFaceViTModelSource implements ViTModelSource {
         return this.properties.repository() + ":" + this.properties.revision();
     }
 
+    @SuppressWarnings("EmptyCatch")
     @Override
     public Path retrieve() {
         final var name =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional proxy support for Discord webhook requests.
  * Added country-based proxy selection using comma-separated ISO country codes, defaulting to US.
  * Proxy connections are validated, cached temporarily, and automatically replaced when unavailable.
  * Improved request URL construction with safely encoded path segments.

* **Documentation**
  * Updated the client configuration table with proxy country settings and usage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add HTTP proxy support for Discord webhook delivery via Proxifly
> - Adds `ProxiflyProxySelector`, which fetches a free proxy list from Proxifly, tests candidates against Discord's gateway with a 2s timeout, and caches the selected proxy for 10 minutes.
> - Controlled by two new settings: `nohorny-discord-webhook-proxy-enabled` (default `false`) and `nohorny-proxy-countries` (default `US`, validated ISO 3166-1 alpha-2 codes).
> - `DiscordWebhook` and `NoHornyClient` now manage their own `HttpClient` lifecycle internally rather than receiving a shared instance from `NoHornyPlugin`.
> - Adds `HttpUtils.appendPathSegments` to safely percent-encode URI path segments, replacing manual string concatenation in API request construction.
> - Risk: proxy refresh runs on every relevant setting change and makes outbound HTTP calls to jsDelivr and Discord; failures are logged but may silently fall back to no proxy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5239f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->