### PR TITLE
Switch from proxifly to proxyscrape

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       - name: "Build Gradle"
         run: ./gradlew build
         env:
-          NOHORNY_TEST_PROXIFLY: "${{ github.event_name != 'release' && 'true' || '' }}"
+          NOHORNY_TEST_PROXYSCRAPE: "${{ github.event_name != 'release' && 'true' || '' }}"
           NOHORNY_TEST_DISCORD_WEBHOOK: "${{ github.event_name != 'release' && secrets.NOHORNY_TEST_DISCORD_WEBHOOK || '' }}"
 
       - name: "Upload Client Jar"

--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ You can configure nohorny using the Mindustry built-in `config` command, with `c
 | `nohorny-discord-webhook`                   | Discord webhook used to report unsafe buildings.                                                                                                                          | empty                              |
 | `nohorny-discord-webhook-name`              | Username used for messages sent through the Discord webhook.                                                                                                              | `NoHorny`                          |
 | `nohorny-discord-webhook-message-retention` | Number of days to keep the report messages sent to the Discord webhook, from `0` to `7` (inclusive). Expired reports are deleted automatically. Set to `null` to disable. | `7`                                |
-| `nohorny-discord-webhook-proxy-enabled`     | Whether discord requests should be proxied. Useful if discord is banned in the country.                                                                                   | `false`                            |
+| `nohorny-discord-webhook-proxy-enabled`     | Whether discord requests should be proxied. Useful if discord is banned in the country. Uses [ProxyScrape](https://proxyscrape.com/free-proxy-list)                       | `false`                            |
 | `nohorny-debug-tap`                         | Enables admin double-tap debugging for tracked displays and canvases.                                                                                                     | `false`                            |
-| `nohorny-proxy-countries`                   | Comma-separated ISO country codes to select a proxy from the [Proxifly free proxy list](https://github.com/proxifly/free-proxy-list/blob/main/proxies/meta/data.json).    | `US`                               |
 
 #### Auto-Mod Policies
 

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/DiscordWebhook.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/DiscordWebhook.java
@@ -49,7 +49,7 @@ final class DiscordWebhook implements LifecycleListener {
 
     private final String userAgent;
 
-    private final ProxiflyProxySelector proxy = new ProxiflyProxySelector(this.executor);
+    private final ProxyScrapeProxySelector proxy = new ProxyScrapeProxySelector(this.executor);
     private final HttpClient http =
             HttpClient.newBuilder().executor(this.executor).proxy(this.proxy).build();
     private final MonoRateLimiter rateLimiter = new MonoRateLimiter(Duration.ofSeconds(1));
@@ -76,8 +76,7 @@ final class DiscordWebhook implements LifecycleListener {
         MindustryUtils.onEvent(SettingChangeEvent.class, event -> {
             if (!(event.key().equals(NoHornySetting.DISCORD_WEBHOOK)
                     || event.key().equals(NoHornySetting.DISCORD_WEBHOOK_NAME)
-                    || event.key().equals(NoHornySetting.DISCORD_WEBHOOK_PROXY_ENABLED)
-                    || event.key().equals(NoHornySetting.PROXY_COUNTRIES))) {
+                    || event.key().equals(NoHornySetting.DISCORD_WEBHOOK_PROXY_ENABLED))) {
                 return;
             }
             this.executor.execute(() -> {

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/NoHornySetting.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/NoHornySetting.java
@@ -81,13 +81,6 @@ public interface NoHornySetting<T> {
             eg: "7".
             """, 7, Integer.class, new SettingCodec.OfInteger(0, 7));
 
-    NoHornySetting<String> PROXY_COUNTRIES =
-            new AdminConfigNoHornySetting<>("proxy-countries", """
-            Comma separated list of ISO 3166-1 alpha-2 country codes used to select a proxy.
-            Setting this to null defaults to the "US".
-            eg: "FR,DE,US".
-            """, "US", String.class, SettingCodec.OfCountryCodeList);
-
     List<NoHornySetting<?>> ALL = List.of(
             API_ENDPOINT,
             API_AUTH_TYPE,
@@ -97,8 +90,7 @@ public interface NoHornySetting<T> {
             DISCORD_WEBHOOK_PROXY_ENABLED,
             DISCORD_WEBHOOK_MESSAGE_RETENTION,
             AUTOMOD_POLICY,
-            DEBUG_TAP,
-            PROXY_COUNTRIES);
+            DEBUG_TAP);
 
     String name();
 

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/ProxyScrapeProxySelector.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/ProxyScrapeProxySelector.java
@@ -2,7 +2,10 @@
 package com.xpdustry.nohorny.client;
 
 import arc.util.serialization.Jval;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
@@ -19,10 +22,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executor;
@@ -32,12 +33,12 @@ import java.util.concurrent.TimeUnit;
 import javax.net.ssl.HttpsURLConnection;
 import org.jspecify.annotations.Nullable;
 
-final class ProxiflyProxySelector extends ProxySelector implements AutoCloseable {
+final class ProxyScrapeProxySelector extends ProxySelector implements AutoCloseable {
 
-    private static final MiniLogger log = MiniLogger.forClass(ProxiflyProxySelector.class);
+    private static final MiniLogger log = MiniLogger.forClass(ProxyScrapeProxySelector.class);
 
-    private static final URI PROXY_LIST_ENDPOINT =
-            URI.create("https://cdn.jsdelivr.net/gh/proxifly/free-proxy-list@main/proxies/countries/");
+    private static final URI PROXY_LIST_ENDPOINT = URI.create(
+            "https://api.proxyscrape.com/v4/free-proxy-list/get?request=display_proxies&proxy_format=ipport&format=text");
     private static final URL DISCORD_STATUS_ENDPOINT;
 
     static {
@@ -50,11 +51,11 @@ final class ProxiflyProxySelector extends ProxySelector implements AutoCloseable
     }
 
     private static final Duration PROXY_LIST_TIMEOUT = Duration.ofSeconds(2);
-    private static final Duration PROXY_CONNECT_TIMEOUT = Duration.ofSeconds(2);
-    private static final Duration PROXY_READ_TIMEOUT = Duration.ofSeconds(2);
+    private static final Duration PROXY_CONNECT_TIMEOUT = Duration.ofSeconds(4);
+    private static final Duration PROXY_READ_TIMEOUT = Duration.ofSeconds(4);
     private static final Duration PROXY_BATCH_TIMEOUT =
             PROXY_CONNECT_TIMEOUT.plus(PROXY_READ_TIMEOUT).plusSeconds(1L);
-    private static final int TEST_BATCH_SIZE = 128;
+    private static final int TEST_BATCH_SIZE = 32;
 
     private final Executor executor;
     private final HttpClient http;
@@ -62,7 +63,7 @@ final class ProxiflyProxySelector extends ProxySelector implements AutoCloseable
     private @Nullable Proxy proxy = null;
     private Instant refreshAt = Instant.MIN;
 
-    ProxiflyProxySelector(final Executor executor) {
+    ProxyScrapeProxySelector(final Executor executor) {
         this.executor = executor;
         this.http = HttpClient.newBuilder()
                 .connectTimeout(PROXY_LIST_TIMEOUT)
@@ -111,10 +112,7 @@ final class ProxiflyProxySelector extends ProxySelector implements AutoCloseable
             }
 
             final var start = System.currentTimeMillis();
-            final var countries = Objects.requireNonNullElse(NoHornySetting.PROXY_COUNTRIES.get(), "US");
-            final var proxies = this.fetchProxies(Arrays.stream(countries.split(",", -1))
-                    .map(c -> c.toUpperCase(Locale.ROOT))
-                    .toList());
+            final var proxies = this.fetchProxies();
 
             Proxy result = null;
             for (int i = 0; i < proxies.size(); i += TEST_BATCH_SIZE) {
@@ -122,7 +120,7 @@ final class ProxiflyProxySelector extends ProxySelector implements AutoCloseable
                 final var proxy = this.testProxyBatch(batch);
                 if (proxy != null) {
                     log.debug(
-                            "Selected the Proxifly proxy {} in {}ms",
+                            "Selected the ProxyScrape proxy {} in {}ms",
                             proxy.address(),
                             System.currentTimeMillis() - start);
                     result = proxy;
@@ -133,7 +131,7 @@ final class ProxiflyProxySelector extends ProxySelector implements AutoCloseable
                 this.proxy = result;
                 this.refreshAt = Instant.now().plus(10, ChronoUnit.MINUTES);
             } else {
-                log.error("No working Proxifly proxy was found for the countries {}", countries);
+                log.error("No working ProxyScrape proxy was found");
                 this.proxy = null;
                 this.refreshAt = Instant.MIN;
             }
@@ -236,60 +234,49 @@ final class ProxiflyProxySelector extends ProxySelector implements AutoCloseable
         }
     }
 
-    // TODO Parallelize too?
     @SuppressWarnings("EmptyCatch")
-    private List<InetSocketAddress> fetchProxies(final List<String> countries) {
-        final var addresses = new HashSet<InetSocketAddress>();
-        for (final var country : countries) {
-            final var request = HttpRequest.newBuilder(
-                            HttpUtils.appendPathSegments(PROXY_LIST_ENDPOINT, country, "data.json"))
-                    .timeout(PROXY_LIST_TIMEOUT)
-                    .GET()
-                    .build();
-            final HttpResponse<String> response;
-            try {
-                response = this.http.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
-            } catch (final InterruptedException e) {
-                Thread.currentThread().interrupt();
-                continue;
-            } catch (final IOException e) {
-                log.error("Failed to fetch the Proxifly proxy list of {}", country, e);
-                continue;
-            }
-            if (response.statusCode() != 200) {
-                log.error("The Proxifly proxy list of {} returned the http code {}", country, response.statusCode());
-                continue;
-            }
-            try {
-                for (final var element : Jval.read(response.body()).asArray()) {
-                    try {
-                        final var address = this.parseProxy(element);
-                        if (address != null) {
-                            addresses.add(address);
-                        }
-                    } catch (final Exception _) {
+    private List<InetSocketAddress> fetchProxies() {
+        final var addresses = new ArrayList<InetSocketAddress>();
+        final var request = HttpRequest.newBuilder(PROXY_LIST_ENDPOINT)
+                .timeout(PROXY_LIST_TIMEOUT)
+                .GET()
+                .build();
+        final HttpResponse<InputStream> response;
+        try {
+            response = this.http.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return List.of();
+        } catch (final IOException e) {
+            log.error("Failed to fetch the ProxyScrape proxy list", e);
+            return List.of();
+        }
+        if (response.statusCode() != 200) {
+            log.error("The ProxyScrape proxy list returned http code {}", response.statusCode());
+            return List.of();
+        }
+        try (final var stream = response.body();
+                final var reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                try {
+                    final var split = line.lastIndexOf(':');
+                    if (split == -1) {
+                        continue;
                     }
+                    final var address = InetAddress.ofLiteral(line.substring(0, split));
+                    final var port = Integer.parseInt(line.substring(split + 1));
+                    if (port <= 0 || port > 65535) {
+                        continue;
+                    }
+                    addresses.add(new InetSocketAddress(address, port));
+                } catch (final IllegalArgumentException _) {
                 }
-            } catch (final Exception e) {
-                log.error("Failed to parse the Proxifly proxy list of {}", country, e);
             }
+        } catch (final Exception e) {
+            log.error("Failed to parse the ProxyScrape list", e);
         }
-        return List.copyOf(addresses);
-    }
-
-    private @Nullable InetSocketAddress parseProxy(final Jval element) {
-        if (!(element.getString("protocol", "").equals("http") && element.getBool("https", false))) {
-            return null;
-        }
-        final var ip = element.getString("ip", "");
-        if (ip.isEmpty()) {
-            return null;
-        }
-        final var port = element.getInt("port", -1);
-        if (port <= 0 || port > 65535) {
-            return null;
-        }
-        return new InetSocketAddress(InetAddress.ofLiteral(ip), port);
+        return Collections.unmodifiableList(addresses);
     }
 
     @Override

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/ProxyScrapeProxySelector.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/ProxyScrapeProxySelector.java
@@ -2,10 +2,7 @@
 package com.xpdustry.nohorny.client;
 
 import arc.util.serialization.Jval;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
@@ -22,7 +19,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -237,14 +233,13 @@ final class ProxyScrapeProxySelector extends ProxySelector implements AutoClosea
 
     @SuppressWarnings("EmptyCatch")
     private List<InetSocketAddress> fetchProxies() {
-        final var addresses = new ArrayList<InetSocketAddress>();
         final var request = HttpRequest.newBuilder(PROXY_LIST_ENDPOINT)
                 .timeout(PROXY_LIST_TIMEOUT)
                 .GET()
                 .build();
-        final HttpResponse<InputStream> response;
+        final HttpResponse<String> response;
         try {
-            response = this.http.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            response = this.http.send(request, HttpResponse.BodyHandlers.ofString());
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             return List.of();
@@ -254,34 +249,39 @@ final class ProxyScrapeProxySelector extends ProxySelector implements AutoClosea
         }
         if (response.statusCode() != 200) {
             log.error("The ProxyScrape proxy list returned http code {}", response.statusCode());
-            try {
-                response.body().close();
-            } catch (final IOException _) {
-            }
             return List.of();
         }
-        try (final var stream = response.body();
-                final var reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
-            String line;
-            while ((line = reader.readLine()) != null && addresses.size() < PROXY_LIST_SIZE_LIMIT) {
-                try {
+
+        return response.body()
+                .lines()
+                .map(line -> {
                     final var split = line.lastIndexOf(':');
                     if (split == -1) {
-                        continue;
+                        return null;
                     }
-                    final var address = InetAddress.ofLiteral(line.substring(0, split));
-                    final var port = Integer.parseInt(line.substring(split + 1));
+
+                    final InetAddress address;
+                    try {
+                        address = InetAddress.ofLiteral(line.substring(0, split));
+                    } catch (final IllegalArgumentException _) {
+                        return null;
+                    }
+
+                    final int port;
+                    try {
+                        port = Integer.parseInt(line.substring(split + 1));
+                    } catch (final NumberFormatException _) {
+                        return null;
+                    }
                     if (port <= 0 || port > 65535) {
-                        continue;
+                        return null;
                     }
-                    addresses.add(new InetSocketAddress(address, port));
-                } catch (final IllegalArgumentException _) {
-                }
-            }
-        } catch (final Exception e) {
-            log.error("Failed to parse the ProxyScrape list", e);
-        }
-        return Collections.unmodifiableList(addresses);
+
+                    return new InetSocketAddress(address, port);
+                })
+                .filter(Objects::nonNull)
+                .limit(PROXY_LIST_SIZE_LIMIT)
+                .toList();
     }
 
     @Override

--- a/nohorny-client/src/main/java/com/xpdustry/nohorny/client/ProxyScrapeProxySelector.java
+++ b/nohorny-client/src/main/java/com/xpdustry/nohorny/client/ProxyScrapeProxySelector.java
@@ -38,7 +38,7 @@ final class ProxyScrapeProxySelector extends ProxySelector implements AutoClosea
     private static final MiniLogger log = MiniLogger.forClass(ProxyScrapeProxySelector.class);
 
     private static final URI PROXY_LIST_ENDPOINT = URI.create(
-            "https://api.proxyscrape.com/v4/free-proxy-list/get?request=display_proxies&proxy_format=ipport&format=text");
+            "https://api.proxyscrape.com/v4/free-proxy-list/get?request=display_proxies&protocol=http&ssl=yes&proxy_format=ipport&format=text");
     private static final URL DISCORD_STATUS_ENDPOINT;
 
     static {
@@ -56,6 +56,7 @@ final class ProxyScrapeProxySelector extends ProxySelector implements AutoClosea
     private static final Duration PROXY_BATCH_TIMEOUT =
             PROXY_CONNECT_TIMEOUT.plus(PROXY_READ_TIMEOUT).plusSeconds(1L);
     private static final int TEST_BATCH_SIZE = 32;
+    private static final int PROXY_LIST_SIZE_LIMIT = 256;
 
     private final Executor executor;
     private final HttpClient http;
@@ -253,12 +254,16 @@ final class ProxyScrapeProxySelector extends ProxySelector implements AutoClosea
         }
         if (response.statusCode() != 200) {
             log.error("The ProxyScrape proxy list returned http code {}", response.statusCode());
+            try {
+                response.body().close();
+            } catch (final IOException _) {
+            }
             return List.of();
         }
         try (final var stream = response.body();
                 final var reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
             String line;
-            while ((line = reader.readLine()) != null) {
+            while ((line = reader.readLine()) != null && addresses.size() < PROXY_LIST_SIZE_LIMIT) {
                 try {
                     final var split = line.lastIndexOf(':');
                     if (split == -1) {

--- a/nohorny-client/src/test/java/com/xpdustry/nohorny/client/ProxyScrapeProxySelectorTest.java
+++ b/nohorny-client/src/test/java/com/xpdustry/nohorny/client/ProxyScrapeProxySelectorTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-final class ProxiflyProxySelectorTest {
+final class ProxyScrapeProxySelectorTest {
 
     @BeforeEach
     void before() {
@@ -27,14 +27,13 @@ final class ProxiflyProxySelectorTest {
         Core.settings = null;
     }
 
-    @EnabledIfEnvironmentVariable(named = "NOHORNY_TEST_PROXIFLY", matches = "true|1")
+    @EnabledIfEnvironmentVariable(named = "NOHORNY_TEST_PROXYSCRAPE", matches = "true|1")
     @Test
-    void select_working_proxy_from_live_proxifly_list() {
-        NoHornySetting.PROXY_COUNTRIES.set("DE,NL,US,JP");
+    void select_working_proxy_from_live_proxyScrape_list() {
         try (final var executor = Executors.newVirtualThreadPerTaskExecutor()) {
-            final var selector = new ProxiflyProxySelector(executor);
+            final var selector = new ProxyScrapeProxySelector(executor);
             final var proxy = selector.refresh(true);
-            assertNotNull(proxy, "Expected a Proxifly HTTP proxy capable of reaching Discord's gateway endpoint");
+            assertNotNull(proxy, "Expected a ProxyScrape HTTP proxy capable of reaching Discord's gateway endpoint");
             assertEquals(Proxy.Type.HTTP, proxy.type());
             assertInstanceOf(InetSocketAddress.class, proxy.address());
         }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch proxy provider from Proxifly to ProxyScrape in Discord webhook client
> - Replaces `ProxiflyProxySelector` with `ProxyScrapeProxySelector`, which fetches proxies from the ProxyScrape text API (`ip:port` format) instead of Proxifly's JSON API.
> - Removes the `proxy-countries` configuration setting; proxy list is now fetched unconditionally without country filtering.
> - Adjusts proxy testing: connect/read timeouts increase from 2s to 4s, batch size reduces from 128 to 32, and the proxy list is capped at 256 entries.
> - Behavioral Change: `PROXY_COUNTRIES` is no longer a valid setting and will not trigger proxy refresh; existing configs referencing it will have no effect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b8fef3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord webhook connections now use ProxyScrape as the proxy source.
  * Proxy lists are fetched from ProxyScrape and validated before use.
* **Changes**
  * Removed the proxy-country configuration setting.
  * Increased proxy connection and read timeouts for improved reliability.
* **Documentation**
  * Updated setup guidance to reference ProxyScrape and removed obsolete proxy-country configuration details.
* **Bug Fixes**
  * Improved handling of invalid proxy entries and network, parsing, and interruption errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->